### PR TITLE
Strip command output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - **Fixed** merging tool umbrella opts with those set in ancestor config
+- **Fixed** command output streaming & reprinting to trim leading & trailing whitespace
 
 ## v0.11.0
 

--- a/lib/ex_check/check.ex
+++ b/lib/ex_check/check.ex
@@ -122,16 +122,19 @@ defmodule ExCheck.Check do
       |> Command.unsilence()
       |> Command.await()
 
-    if output_needs_padding?(output), do: Printer.info()
     IO.write(IO.ANSI.reset())
+    print_padding(output)
 
     status = if code == 0, do: :ok, else: :error
 
     {status, {name, cmd, opts}, {code, output, duration}}
   end
 
-  defp output_needs_padding?(output) do
-    not (String.match?(output, ~r/\n{2,}$/) or output == "")
+  defp print_padding(""), do: :ok
+
+  defp print_padding(_) do
+    Printer.info()
+    Printer.info()
   end
 
   defp reprint_errors(failed_tools) do
@@ -139,7 +142,8 @@ defmodule ExCheck.Check do
       Printer.info([:red, "=> reprinting errors from "] ++ format_tool_name(name))
       Printer.info()
       IO.write(output)
-      if output_needs_padding?(output), do: Printer.info()
+      IO.write(IO.ANSI.reset())
+      print_padding(output)
     end)
   end
 


### PR DESCRIPTION
This PR aims to make the process of streaming & collecting output from arbitrary commands more predictable in terms of output padding. This helps in wrapping output from commands in pre/post messages & misc decorators without messing things up.