### PR TITLE
docs: Correct README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ def project do
     preferred_cli_env: [
       check: :test,
       credo: :test,
-      dialyxir: :test,
+      dialyzer: :test,
       sobelow: :test
     ]
   ]


### PR DESCRIPTION
Following instructions as written results in `no app found` errors for Dialyzer. 