### PR TITLE
feat: Add config directory opt to CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.13.0-dev
 
 - **Added** `:unused_deps` tool
+- **Added** `--config-file` opt to point to arbitrary configuration file path
 
 ## v0.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.13.0-dev
 
 - **Added** `:unused_deps` tool
-- **Added** `--config-file` opt to point to arbitrary configuration file path
+- **Added** `--config` opt to point to arbitrary configuration file path
 
 ## v0.12.0
 

--- a/lib/ex_check/check.ex
+++ b/lib/ex_check/check.ex
@@ -5,7 +5,7 @@ defmodule ExCheck.Check do
   alias __MODULE__.{Compiler, Pipeline}
 
   def run(opts) do
-    {tools, config_opts} = Config.load()
+    {tools, config_opts} = Config.load(opts)
     opts = Keyword.merge(config_opts, opts)
 
     compile_and_run_tools(tools, opts)

--- a/lib/ex_check/check.ex
+++ b/lib/ex_check/check.ex
@@ -8,7 +8,12 @@ defmodule ExCheck.Check do
   alias ExCheck.Printer
 
   def run(opts) do
-    {tools, config_opts} = Config.load(opts)
+    {tools, config_opts} =
+      opts
+      |> Keyword.put(:file, opts[:config])
+      |> Keyword.delete(:config)
+      |> Config.load()
+
     opts = Keyword.merge(config_opts, opts)
 
     compile_and_run_tools(tools, opts)

--- a/lib/ex_check/config.ex
+++ b/lib/ex_check/config.ex
@@ -1,8 +1,6 @@
 defmodule ExCheck.Config do
   @moduledoc false
 
-  alias __MODULE__.{Generator, Loader}
-
-  defdelegate generate, to: Generator
-  defdelegate load, to: Loader
+  defdelegate generate, to: ExCheck.Config.Generator
+  defdelegate load(opts), to: ExCheck.Config.Loader
 end

--- a/lib/ex_check/config/loader.ex
+++ b/lib/ex_check/config/loader.ex
@@ -16,20 +16,23 @@ defmodule ExCheck.Config.Loader do
     user_dir_config = config_filename(System.user_home())
     project_root_config = config_filename(Project.get_mix_root_dir())
 
-    dirs = config_file ++ [user_dir_config, project_root_config]
+    files = config_file ++ user_dir_config ++ project_root_config
 
     default_config = normalize_config(DefaultConfig.get())
-    config = load_from_files(dirs, default_config)
+    config = load_from_files(files, default_config)
     tools = Keyword.fetch!(config, :tools)
     opts = Keyword.take(config, @option_list)
 
     {tools, opts}
   end
 
+  defp config_filename(nil), do: []
+
   defp config_filename(directory) do
     directory
     |> Path.join(@config_filename)
     |> Path.expand()
+    |> List.wrap()
   end
 
   # sobelow_skip ["RCE.CodeModule"]

--- a/lib/ex_check/config/loader.ex
+++ b/lib/ex_check/config/loader.ex
@@ -10,7 +10,7 @@ defmodule ExCheck.Config.Loader do
   def load(opts) do
     config_file =
       opts
-      |> Keyword.get(:config_file)
+      |> Keyword.get(:file)
       |> List.wrap()
 
     user_dir_config = config_filename(System.user_home())

--- a/lib/ex_check/config/loader.ex
+++ b/lib/ex_check/config/loader.ex
@@ -7,11 +7,16 @@ defmodule ExCheck.Config.Loader do
   @config_filename ".check.exs"
   @option_list [:parallel, :skipped]
 
-  def load do
-    user_home_dir = System.user_home()
-    user_dirs = if user_home_dir, do: [user_home_dir], else: []
+  def load(user_opts) do
+    user_config_dir =
+      user_opts
+      |> Keyword.get(:config_directory)
+      |> List.wrap()
+
+    user_dirs = List.wrap(System.user_home())
     project_root_dir = Project.get_mix_root_dir()
-    dirs = user_dirs ++ [project_root_dir]
+
+    dirs = user_config_dir ++ user_dirs ++ [project_root_dir]
 
     default_config = normalize_config(DefaultConfig.get())
     config = load_from_dirs(dirs, default_config)

--- a/lib/mix/tasks/check.ex
+++ b/lib/mix/tasks/check.ex
@@ -168,7 +168,7 @@ defmodule Mix.Tasks.Check do
   Task will load the configuration in following order:
 
   1. Default stock configuration.
-  2. `.check.exs` in `--config-directory` opt on command line.
+  2. `--config-file` file opt on command line.
   3. `.check.exs` in user home directory.
   4. `.check.exs` in current project directory (or umbrella root for an umbrella project).
 
@@ -176,7 +176,7 @@ defmodule Mix.Tasks.Check do
 
   ## Command line options
 
-  - `--config-directory /some/directory` - Override default config lookup directory
+  - `--config-file /some/file` - Override default config file
   - `--only dialyzer --only credo ...` - run only specified check(s)
   - `--except dialyzer --except credo ...` - don't run specified check(s)
   - `--no-parallel` - don't run tools in parallel
@@ -206,7 +206,7 @@ defmodule Mix.Tasks.Check do
     skipped: :boolean,
     exit_status: :boolean,
     parallel: :boolean,
-    config_directory: :string
+    config_file: :string
   ]
 
   @impl Mix.Task

--- a/lib/mix/tasks/check.ex
+++ b/lib/mix/tasks/check.ex
@@ -168,7 +168,7 @@ defmodule Mix.Tasks.Check do
   Task will load the configuration in following order:
 
   1. Default stock configuration.
-  2. `--config-file` file opt on command line.
+  2. `--config` file opt on command line.
   3. `.check.exs` in user home directory.
   4. `.check.exs` in current project directory (or umbrella root for an umbrella project).
 
@@ -176,7 +176,7 @@ defmodule Mix.Tasks.Check do
 
   ## Command line options
 
-  - `--config-file /some/file` - Override default config file
+  - `--config /some/file` - Override default config file
   - `--only dialyzer --only credo ...` - run only specified check(s)
   - `--except dialyzer --except credo ...` - don't run specified check(s)
   - `--no-parallel` - don't run tools in parallel
@@ -206,7 +206,7 @@ defmodule Mix.Tasks.Check do
     skipped: :boolean,
     exit_status: :boolean,
     parallel: :boolean,
-    config_file: :string
+    config: :string
   ]
 
   @impl Mix.Task

--- a/lib/mix/tasks/check.ex
+++ b/lib/mix/tasks/check.ex
@@ -165,13 +165,15 @@ defmodule Mix.Tasks.Check do
   Task will load the configuration in following order:
 
   1. Default stock configuration.
-  2. `.check.exs` in user home directory.
-  3. `.check.exs` in current project directory (or umbrella root for an umbrella project).
+  2. `.check.exs` in `--config-directory` opt on command line.
+  3. `.check.exs` in user home directory.
+  4. `.check.exs` in current project directory (or umbrella root for an umbrella project).
 
   Use the `mix check.gen.config` task to generate sample configuration that comes with well-commented examples to help you get started.
 
   ## Command line options
 
+  - `--config-directory /some/directory` - Override default config lookup directory
   - `--only dialyzer --only credo ...` - run only specified check(s)
   - `--except dialyzer --except credo ...` - don't run specified check(s)
   - `--no-parallel` - don't run tools in parallel
@@ -199,7 +201,8 @@ defmodule Mix.Tasks.Check do
     except: :keep,
     skipped: :boolean,
     exit_status: :boolean,
-    parallel: :boolean
+    parallel: :boolean,
+    config_directory: :string
   ]
 
   @impl Mix.Task


### PR DESCRIPTION
Resolves #16 

Note: I unfolded the `__MODULE__` alias expansion because I found grepping for where the `EXCheck.Config.*` modules were being used was tougher than it should have been, so I resolved this for future folks by making it possible to grep for the fully qualified name of the modules. I can put this back if you'd like, but I think it's a positive change. 

I tested this locally, but how would you like this tested for posterity?