### PR TITLE
Retry command for `--failed` & `--fix` mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.14.0-dev
+
+- **Added** `--fix` command line option that runs tools in fix mode in order to resolve issues automatically along with `:fix` tool option
+- **Added** capability to run tool command to retry after failure e.g. in order to run only failed tests or checks along with `:retry` tool option
+
 ## v0.13.0
 
 - **Added** `:unused_deps` tool

--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ Yes, `ex_check` uses itself on the CI. Yay for recursion!
 
 ### Autofixing
 
-You may automatically fix trivial issues by triggering the fix mode on the CI as well. In order to
-do so, you'll need a CI script or workflow similar to the example below:
+You may automatically fix and commit back trivial issues by triggering the fix mode on the CI as
+well. In order to do so, you'll need a CI script or workflow similar to the example below:
 
 ```bash
 mix check --fix && \
@@ -176,8 +176,8 @@ mix check --fix && \
   git push
 ```
 
-This script performs the fixing and, if no unfixable issues have occurred, checks whether any
-changes were actually made. If so, it commits and pushes these changes automatically.
+This script performs the check in fix mode and, if no unfixable issues have occurred, checks whether
+any fixes were actually made. If so, it proceeds to commit and push these fixes.
 
 Of course your CI will need to have write permissions to the source repository.
 

--- a/README.md
+++ b/README.md
@@ -153,12 +153,45 @@ With `mix check` you can consistently run the same set of checks locally and on 
 configuration also becomes trivial and comes out of the box with parallelism and error output from
 all checks at once regardless of which ones have failed.
 
-Like on a local machine, all you have to do in order to use `ex_check` on CI is run `mix check` instead of `mix test`. This repo features working CI configs for following providers:
+Like on a local machine, all you have to do in order to use `ex_check` on CI is run `mix check`
+instead of `mix test`. This repo features working CI configs for following providers:
 
 - GitHub - [.github/workflows/check.yml](https://github.com/karolsluszniak/ex_check/blob/master/.github/workflows/check.yml)
 - Travis - [.travis.yml](https://github.com/karolsluszniak/ex_check/blob/master/.travis.yml)
 
 Yes, `ex_check` uses itself on the CI. Yay for recursion!
+
+### Autofixing
+
+You may automatically fix trivial issues by triggering the fix mode on the CI as well. In order to
+do so, you'll need a CI script or workflow similar to the example below:
+
+```bash
+mix check --fix && \
+  git diff-index --quiet HEAD -- && \
+  git config --global user.name 'Autofix' && \
+  git config --global user.email 'autofix@example.com' && \
+  git add --all && \
+  git commit --message "Autofix" && \
+  git push
+```
+
+This script performs the fixing and, if no unfixable issues have occurred, checks whether any
+changes were actually made. If so, it commits and pushes these changes automatically.
+
+Of course your CI will need to have write permissions to the source repository.
+
+### Random failues
+
+You may take advantage of the automatic retry feature to efficiently re-run failed tools & tests
+multiple times. For instance, following shell command runs check up to three times: `mix check ||
+mix check || mix check`. And here goes an alternative without the logical operators:
+
+```bash
+mix check
+mix check --failed
+mix check --failed
+```
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ![ex_check](https://raw.githubusercontent.com/karolsluszniak/ex_check/master/logo.svg) ex_check
+# ![ex_check](./logo-with-name.svg)
 
 [![License](https://img.shields.io/github/license/karolsluszniak/ex_check.svg)](https://github.com/karolsluszniak/ex_check/blob/master/LICENSE.md)
 [![Build status (GitHub Actions)](https://img.shields.io/github/workflow/status/karolsluszniak/ex_check/check/master?logo=github)](https://github.com/karolsluszniak/ex_check/actions)

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Takes seconds to setup, saves hours in the long term.
 - Comes out of the box with a [predefined set of curated tools](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-tools), including NPM integration for Phoenix assets
 - Delivers results faster by [running tools in parallel and identifying all project issues in one go](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-workflow)
 - Checks the project consistently on every developer's local machine & [on the CI](https://github.com/karolsluszniak/ex_check#continuous-integration)
-- Allows to retry checks that have [failed in the last run](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-retrying-failed-tools)
-- Fixes issues automatically via support for [the fix mode](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-fix-mode)
+- Runs only the tools & tests that have [failed in the last run](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-retrying-failed-tools)
+- Fixes issues automatically in [the fix mode](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-fix-mode)
 
 Sports powerful features to enable ultimate flexibility.
 - Add custom mix tasks, shell scripts and commands via [configuration file](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-configuration-file)

--- a/README.md
+++ b/README.md
@@ -30,9 +30,7 @@ Takes care of the little details, so you don't have to.
 - Ensures that output from tools is [ANSI formatted & colorized](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-tool-processes-and-ansi-formatting)
 - Retries ExUnit with the `--failed` flag
 
-Read more in the introductory ["One task to rule all Elixir analysis & testing
-tools"](http://cloudless.studio/articles/49-one-task-to-rule-all-elixir-analysis-testing-tools)
-article.
+Read more in the introductory ["One task to rule all Elixir analysis & testing tools"](http://cloudless.studio/articles/49-one-task-to-rule-all-elixir-analysis-testing-tools) article.
 
 ## Getting started
 
@@ -92,6 +90,55 @@ Among others, this allows to permamently disable specific tools and avoid the sk
 ]
 ```
 
+## Documentation
+
+Learn more about the tools included in the check as well as its workflow, configuration and options [on HexDocs](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html) or by running `mix help check`.
+
+Want to write your own code check? Get yourself started by reading the ["Writing your first Elixir code check"](http://cloudless.studio/articles/50-writing-your-first-elixir-code-check) article.
+
+## Continuous Integration
+
+With `mix check` you can consistently run the same set of checks locally and on the CI. CI configuration also becomes trivial and comes out of the box with parallelism and error output from all checks at once regardless of which ones have failed.
+
+Like on a local machine, all you have to do in order to use `ex_check` on CI is run `mix check` nstead of `mix test`. This repo features working CI configs for following providers:
+
+- GitHub - [.github/workflows/check.yml](https://github.com/karolsluszniak/ex_check/blob/master/.github/workflows/check.yml)
+- Travis - [.travis.yml](https://github.com/karolsluszniak/ex_check/blob/master/.travis.yml)
+
+Yes, `ex_check` uses itself on the CI. Yay for recursion!
+
+### Autofixing
+
+You may automatically fix and commit back trivial issues by triggering the fix mode on the CI as well. In order to do so, you'll need a CI script or workflow similar to the example below:
+
+```bash
+mix check --fix && \
+  git diff-index --quiet HEAD -- && \
+  git config --global user.name 'Autofix' && \
+  git config --global user.email 'autofix@example.com' && \
+  git add --all && \
+  git commit --message "Autofix" && \
+  git push
+```
+
+First, we perform the check in the fix mode. Then, if no unfixable issues have occurred and if fixes were actually made, we proceed to commit and push these fixes.
+
+Of course your CI will need to have write permissions to the source repository.
+
+### Random failures
+
+You may take advantage of the automatic retry feature to efficiently re-run failed tools & tests multiple times. For instance, following shell command runs check up to three times: `mix check || mix check || mix check`. And here goes an alternative without the logical operators:
+
+```bash
+mix check
+mix check --failed
+mix check --failed
+```
+
+This will work as expected because the `--failed` flag will ensure that only failed tools are executed, resulting in no-op if previous run has succeeded.
+
+## Troubleshooting
+
 ### Avoiding duplicate builds
 
 If, as suggested above, you've added `ex_check` and curated tools to `only: [:dev]`, you're keeping the test environment reserved for `ex_unit`. While a clean setup, it comes at the expense of Mix having to compile your app twice - in order to prepare `:test` build just for `ex_unit` and `:dev` build for other tools. This costs precious time both on local machine and on the CI. It may also cause issues if you set `MIX_ENV=test`, which is a common practice on the CI.
@@ -139,63 +186,6 @@ Above setup will consistently check the project using just the test build, both 
 ### Avoiding false negatives of `unused_deps` check
 
 You may encounter an issue with the `unused_deps` check failing on the CI while passing locally, caused by fetching only dependencies for specific env. If that happens, remove the `--only test` (or similar) from your `mix deps.get` invocation on the CI to fix the issue.
-
-## Documentation
-
-Learn more about the tools included in the check as well as its workflow, configuration and options
-[on HexDocs](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html) or by running `mix help check`.
-
-Want to write your own code check? Get yourself started by reading the ["Writing your first Elixir
-code check"](http://cloudless.studio/articles/50-writing-your-first-elixir-code-check) article.
-
-## Continuous Integration
-
-With `mix check` you can consistently run the same set of checks locally and on the CI. CI
-configuration also becomes trivial and comes out of the box with parallelism and error output from
-all checks at once regardless of which ones have failed.
-
-Like on a local machine, all you have to do in order to use `ex_check` on CI is run `mix check`
-instead of `mix test`. This repo features working CI configs for following providers:
-
-- GitHub - [.github/workflows/check.yml](https://github.com/karolsluszniak/ex_check/blob/master/.github/workflows/check.yml)
-- Travis - [.travis.yml](https://github.com/karolsluszniak/ex_check/blob/master/.travis.yml)
-
-Yes, `ex_check` uses itself on the CI. Yay for recursion!
-
-### Autofixing
-
-You may automatically fix and commit back trivial issues by triggering the fix mode on the CI as
-well. In order to do so, you'll need a CI script or workflow similar to the example below:
-
-```bash
-mix check --fix && \
-  git diff-index --quiet HEAD -- && \
-  git config --global user.name 'Autofix' && \
-  git config --global user.email 'autofix@example.com' && \
-  git add --all && \
-  git commit --message "Autofix" && \
-  git push
-```
-
-First, we perform the check in the fix mode. Then, if no unfixable issues have occurred and if fixes
-were actually made, we proceed to commit and push these fixes.
-
-Of course your CI will need to have write permissions to the source repository.
-
-### Random failures
-
-You may take advantage of the automatic retry feature to efficiently re-run failed tools & tests
-multiple times. For instance, following shell command runs check up to three times: `mix check ||
-mix check || mix check`. And here goes an alternative without the logical operators:
-
-```bash
-mix check
-mix check --failed
-mix check --failed
-```
-
-This will work as expected because the `--failed` flag will ensure that only failed tools are
-executed, resulting in no-op if previous run has succeeded.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Takes seconds to setup, saves hours in the long term.
 
 Sports powerful features to enable ultimate flexibility.
 - Add custom mix tasks, shell scripts and commands via [configuration file](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-configuration-file)
-- Enhance you CI workflow to [report status](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-manifest-file), [retry random failures](#random-failures) or [autofix](#autofixing)
+- Enhance you CI workflow to [report status](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-manifest-file), [retry random failures](#random-failures) or [autofix issues](#autofixing)
 - Empower umbrella projects with [parallel recursion over child apps](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-umbrella-projects)
-- Design complex parallel workflows with [cross-tool dependencies](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-cross-tool-dependencies)
+- Design complex parallel workflows with [cross-tool deps](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-cross-tool-dependencies)
 
 Takes care of the little details, so you don't have to.
 - Compiles the project and collects compilation warnings in one go
@@ -182,7 +182,7 @@ any fixes were actually made. If so, it proceeds to commit and push these fixes.
 
 Of course your CI will need to have write permissions to the source repository.
 
-### Random failues
+### Random failures
 
 You may take advantage of the automatic retry feature to efficiently re-run failed tools & tests
 multiple times. For instance, following shell command runs check up to three times: `mix check ||

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ mix check
 
 That's it - `mix check` will detect and run all the available tools.
 
-### Configuring tools
+### Tool configuration
 
 If you want to take advantage of curated tools, add following dependencies in `mix.exs`:
 
@@ -89,6 +89,18 @@ Among others, this allows to permamently disable specific tools and avoid the sk
   ]
 ]
 ```
+
+### Local-only configuration
+
+You should keep local and CI configuration as consistent as possible by putting together the project-specific `.check.exs`. Still, you may introduce local-only config by creating the `~/.check.exs` file. This may be useful to enforce global flags on all local runs. For example, the following config will enable the fix mode in local (writeable) envirnoment:
+
+```elixir
+[
+  fix: true
+]
+```
+
+> You may also [enable the fix mode on the CI](#autofixing).
 
 ## Documentation
 
@@ -139,7 +151,7 @@ This will work as expected because the `--failed` flag will ensure that only fai
 
 ## Troubleshooting
 
-### Avoiding duplicate builds
+### Duplicate builds
 
 If, as suggested above, you've added `ex_check` and curated tools to `only: [:dev]`, you're keeping the test environment reserved for `ex_unit`. While a clean setup, it comes at the expense of Mix having to compile your app twice - in order to prepare `:test` build just for `ex_unit` and `:dev` build for other tools. This costs precious time both on local machine and on the CI. It may also cause issues if you set `MIX_ENV=test`, which is a common practice on the CI.
 
@@ -183,7 +195,7 @@ And the following in `.check.exs`:
 
 Above setup will consistently check the project using just the test build, both locally and on the CI.
 
-### Avoiding false negatives of `unused_deps` check
+### `unused_deps` false negatives
 
 You may encounter an issue with the `unused_deps` check failing on the CI while passing locally, caused by fetching only dependencies for specific env. If that happens, remove the `--only test` (or similar) from your `mix deps.get` invocation on the CI to fix the issue.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ---
 
 Takes seconds to setup, saves hours in the long term.
-- Comes out of the box with a [predefined set of curated tools](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-tools), including NPM integration for Phoenix assets
+- Comes out of the box with a [predefined set of curated tools](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-tools)
 - Delivers results faster by [running tools in parallel and identifying all project issues in one go](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-workflow)
 - Checks the project consistently on every developer's local machine & [on the CI](https://github.com/karolsluszniak/ex_check#continuous-integration)
 - Runs only the tools & tests that have [failed in the last run](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-retrying-failed-tools)
@@ -21,13 +21,14 @@ Takes seconds to setup, saves hours in the long term.
 
 Sports powerful features to enable ultimate flexibility.
 - Add custom mix tasks, shell scripts and commands via [configuration file](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-configuration-file)
-- Report status of each check to CI by using [manifest file](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-manifest-file)
+- Enhance you CI workflow to [report status](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-manifest-file), [retry random failures](#random-failures) or [autofix](#autofixing)
 - Empower umbrella projects with [parallel recursion over child apps](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-umbrella-projects)
 - Design complex parallel workflows with [cross-tool dependencies](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-cross-tool-dependencies)
 
 Takes care of the little details, so you don't have to.
 - Compiles the project and collects compilation warnings in one go
-- Ensures that output from tools is still [ANSI formatted & colorized](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-tool-processes-and-ansi-formatting)
+- Ensures that output from tools is [ANSI formatted & colorized](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-tool-processes-and-ansi-formatting)
+- Retries `ex_unit` with the `--failed` flag
 
 Read more in the introductory ["One task to rule all Elixir analysis & testing
 tools"](http://cloudless.studio/articles/49-one-task-to-rule-all-elixir-analysis-testing-tools)
@@ -192,6 +193,9 @@ mix check
 mix check --failed
 mix check --failed
 ```
+
+This will work as expected because the `--failed` flag will ensure that only failed tools are
+executed, resulting in no-op if previous run has succeeded.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 Takes seconds to setup, saves hours in the long term.
 - Comes out of the box with a [predefined set of curated tools](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-tools)
-- Delivers results faster by [running tools in parallel and identifying all project issues in one go](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-workflow)
+- Delivers results faster by [running tools in parallel and catching all issues in one go](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-workflow)
 - Checks the project consistently on every developer's local machine & [on the CI](https://github.com/karolsluszniak/ex_check#continuous-integration)
 - Runs only the tools & tests that have [failed in the last run](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-retrying-failed-tools)
 - Fixes issues automatically in [the fix mode](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-fix-mode)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Sports powerful features to enable ultimate flexibility.
 Takes care of the little details, so you don't have to.
 - Compiles the project and collects compilation warnings in one go
 - Ensures that output from tools is [ANSI formatted & colorized](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-tool-processes-and-ansi-formatting)
-- Retries `ex_unit` with the `--failed` flag
+- Retries ExUnit with the `--failed` flag
 
 Read more in the introductory ["One task to rule all Elixir analysis & testing
 tools"](http://cloudless.studio/articles/49-one-task-to-rule-all-elixir-analysis-testing-tools)

--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ mix check --fix && \
   git push
 ```
 
-This script performs the check in fix mode and, if no unfixable issues have occurred, checks whether
-any fixes were actually made. If so, it proceeds to commit and push these fixes.
+First, we perform the check in the fix mode. Then, if no unfixable issues have occurred and if fixes
+were actually made, we proceed to commit and push these fixes.
 
 Of course your CI will need to have write permissions to the source repository.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Takes seconds to setup, saves hours in the long term.
 - Comes out of the box with a [predefined set of curated tools](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-tools), including NPM integration for Phoenix assets
 - Delivers results faster by [running tools in parallel and identifying all project issues in one go](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-workflow)
 - Checks the project consistently on every developer's local machine & [on the CI](https://github.com/karolsluszniak/ex_check#continuous-integration)
-- Allows to re-run checks that have [failed in the last run](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-manifest-file)
+- Allows to retry checks that have [failed in the last run](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-retrying-failed-tools)
+- Fixes issues automatically via support for [the fix mode](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-fix-mode)
 
 Sports powerful features to enable ultimate flexibility.
 - Add custom mix tasks, shell scripts and commands via [configuration file](https://hexdocs.pm/ex_check/Mix.Tasks.Check.html#module-configuration-file)

--- a/lib/ex_check/check.ex
+++ b/lib/ex_check/check.ex
@@ -171,7 +171,9 @@ defmodule ExCheck.Check do
   end
 
   defp await_tool({:running, {name, cmd, opts}, task}) do
-    Printer.info([:magenta, "=> running "] ++ format_tool_name(name))
+    mode_suffix = if mode = opts[:mode], do: [" in ", b(mode), " mode"], else: []
+
+    Printer.info([:magenta, "=> running "] ++ format_tool_name(name) ++ mode_suffix)
     Printer.info()
     IO.write(IO.ANSI.faint())
 
@@ -219,10 +221,12 @@ defmodule ExCheck.Check do
   defp normalize_tool_name(name = {_, _}), do: name
   defp normalize_tool_name(name), do: {name, 0}
 
-  defp print_summary_item({:ok, {name, _, _}, {_, _, duration}}, _) do
+  defp print_summary_item({:ok, {name, _, opts}, {_, _, duration}}, _) do
     name = format_tool_name(name)
     took = format_duration(duration)
-    Printer.info([:green, " ✓ ", name, " success in ", b(took)])
+    mode = if mode = opts[:mode], do: [" ", to_string(mode)], else: []
+
+    Printer.info([:green, " ✓ ", name, mode, " success in ", b(took)])
   end
 
   defp print_summary_item({:error, {name, _, _}, {code, _, duration}}, _) do

--- a/lib/ex_check/check.ex
+++ b/lib/ex_check/check.ex
@@ -9,16 +9,12 @@ defmodule ExCheck.Check do
   alias ExCheck.Printer
 
   def run(opts) do
-    {tools, config_opts} =
-      opts
-      |> maybe_toggle_retry_mode()
-      |> Keyword.put(:file, opts[:config])
-      |> Keyword.delete(:config)
-      |> Config.load()
+    {tools, config_opts} = Config.load(file: opts[:config])
 
     opts =
       config_opts
       |> Keyword.merge(opts)
+      |> maybe_toggle_retry_mode()
       |> Manifest.convert_failed_to_only()
 
     compile_and_run_tools(tools, opts)

--- a/lib/ex_check/check.ex
+++ b/lib/ex_check/check.ex
@@ -263,6 +263,10 @@ defmodule ExCheck.Check do
     ["missing directory ", b(cd)]
   end
 
+  defp format_skip_reason(:no_fix) do
+    ["no fix"]
+  end
+
   defp format_tool_name(name) when is_atom(name) do
     b(name)
   end

--- a/lib/ex_check/check.ex
+++ b/lib/ex_check/check.ex
@@ -263,10 +263,6 @@ defmodule ExCheck.Check do
     ["missing directory ", b(cd)]
   end
 
-  defp format_skip_reason(:no_fix) do
-    ["no fix"]
-  end
-
   defp format_tool_name(name) when is_atom(name) do
     b(name)
   end

--- a/lib/ex_check/check/compiler.ex
+++ b/lib/ex_check/check/compiler.ex
@@ -202,30 +202,32 @@ defmodule ExCheck.Check.Compiler do
   end
 
   defp prepare_pending(name, tool_opts, opts) do
+    {mode, command} = pick_mode_and_command(tool_opts, opts)
+
     command =
-      tool_opts
-      |> pick_input_cmd(opts)
+      command
       |> command_to_array()
       |> postprocess_cmd(tool_opts)
 
     command_opts =
       tool_opts
       |> Keyword.take([:cd, :env, :deps])
+      |> Keyword.put(:mode, mode)
       |> Keyword.put(:umbrella_parallel, get_in(tool_opts, [:umbrella, :parallel]))
 
     {:pending, {name, command, command_opts}}
   end
 
-  defp pick_input_cmd(tool_opts, opts) do
+  defp pick_mode_and_command(tool_opts, opts) do
     cond do
       opts[:fix] && tool_opts[:fix] ->
-        tool_opts[:fix]
+        {:fix, tool_opts[:fix]}
 
       opts[:failed] && tool_opts[:retry] ->
-        tool_opts[:retry]
+        {:retry, tool_opts[:retry]}
 
       true ->
-        Keyword.fetch!(tool_opts, :command)
+        {nil, Keyword.fetch!(tool_opts, :command)}
     end
   end
 

--- a/lib/ex_check/check/compiler.ex
+++ b/lib/ex_check/check/compiler.ex
@@ -143,9 +143,6 @@ defmodule ExCheck.Check.Compiler do
       tool_opts[:cd] && not File.dir?(tool_opts[:cd]) ->
         {:skipped, name, {:cd, tool_opts[:cd]}}
 
-      opts[:fix] && !tool_opts[:fix] ->
-        {:skipped, name, :no_fix}
-
       true ->
         prepare_pending(name, tool_opts, opts)
     end

--- a/lib/ex_check/check/compiler.ex
+++ b/lib/ex_check/check/compiler.ex
@@ -14,8 +14,9 @@ defmodule ExCheck.Check.Compiler do
     compiler = List.keyfind(tools, :compiler, 0) || raise("compiler tool definition missing")
     compiler = prepare(compiler, opts)
 
-    with {:disabled, _} <- compiler do
-      {:pending, {:compiler, ["mix", "compile"], []}}
+    case compiler do
+      {:pending, _, _} -> compiler
+      _ -> {:pending, {:compiler, ["mix", "compile"], []}}
     end
   end
 
@@ -137,29 +138,16 @@ defmodule ExCheck.Check.Compiler do
         {:disabled, name}
 
       failed_detection = find_failed_detection(name, tool_opts) ->
-        {base, opts} = failed_detection
-
-        case Keyword.get(opts, :else, :skip) do
-          :disable -> {:disabled, name}
-          :skip -> {:skipped, name, base}
-        end
+        prepare_failed_detection(name, failed_detection)
 
       tool_opts[:cd] && not File.dir?(tool_opts[:cd]) ->
         {:skipped, name, {:cd, tool_opts[:cd]}}
 
+      opts[:fix] && !tool_opts[:fix] ->
+        {:skipped, name, :no_fix}
+
       true ->
-        command =
-          tool_opts
-          |> Keyword.fetch!(:command)
-          |> command_to_array()
-          |> postprocess_cmd(tool_opts)
-
-        command_opts =
-          tool_opts
-          |> Keyword.take([:cd, :env, :deps])
-          |> Keyword.put(:umbrella_parallel, get_in(tool_opts, [:umbrella, :parallel]))
-
-        {:pending, {name, command, command_opts}}
+        prepare_pending(name, tool_opts, opts)
     end
   end
 
@@ -206,6 +194,43 @@ defmodule ExCheck.Check.Compiler do
   defp failed_detection?({:package, name, app}), do: not Project.has_dep_in_app?(name, app)
   defp failed_detection?({:package, name}), do: not Project.has_dep?(name)
   defp failed_detection?({:file, name}), do: not File.exists?(name)
+
+  defp prepare_failed_detection(name, failed_detection) do
+    {base, opts} = failed_detection
+
+    case Keyword.get(opts, :else, :skip) do
+      :disable -> {:disabled, name}
+      :skip -> {:skipped, name, base}
+    end
+  end
+
+  defp prepare_pending(name, tool_opts, opts) do
+    command =
+      tool_opts
+      |> pick_input_cmd(opts)
+      |> command_to_array()
+      |> postprocess_cmd(tool_opts)
+
+    command_opts =
+      tool_opts
+      |> Keyword.take([:cd, :env, :deps])
+      |> Keyword.put(:umbrella_parallel, get_in(tool_opts, [:umbrella, :parallel]))
+
+    {:pending, {name, command, command_opts}}
+  end
+
+  defp pick_input_cmd(tool_opts, opts) do
+    cond do
+      opts[:fix] && tool_opts[:fix] ->
+        tool_opts[:fix]
+
+      opts[:failed] && tool_opts[:retry] ->
+        tool_opts[:retry]
+
+      true ->
+        Keyword.fetch!(tool_opts, :command)
+    end
+  end
 
   defp postprocess_cmd(cmd, opts) do
     if Keyword.get(opts, :enable_ansi, true) do

--- a/lib/ex_check/config/default.ex
+++ b/lib/ex_check/config/default.ex
@@ -5,13 +5,15 @@ defmodule ExCheck.Config.Default do
   # streaming to display as many outputs as possible as soon as possible.
   @curated_tools [
     {:compiler, "mix compile --warnings-as-errors --force"},
-    {:formatter, "mix format --check-formatted", detect: [{:file, ".formatter.exs"}]},
+    {:formatter, "mix format --check-formatted",
+     detect: [{:file, ".formatter.exs"}], fix: "mix format"},
     {:credo, "mix credo", detect: [{:package, :credo}]},
     {:sobelow, "mix sobelow --exit", umbrella: [recursive: true], detect: [{:package, :sobelow}]},
     {:ex_doc, "mix docs", detect: [{:package, :ex_doc}]},
-    {:ex_unit, "mix test", detect: [{:file, "test"}]},
+    {:ex_unit, "mix test", detect: [{:file, "test"}], retry: "mix test --failed"},
     {:dialyzer, "mix dialyzer", detect: [{:package, :dialyxir}]},
-    {:unused_deps, "mix deps.unlock --check-unused", detect: [{:elixir, ">= 1.10.0"}]},
+    {:unused_deps, "mix deps.unlock --check-unused",
+     detect: [{:elixir, ">= 1.10.0"}], fix: "mix deps.unlock --unused"},
     {:npm_test, "npm test", cd: "assets", detect: [{:file, "package.json", else: :disable}]}
   ]
 

--- a/lib/ex_check/config/generator.ex
+++ b/lib/ex_check/config/generator.ex
@@ -6,9 +6,14 @@ defmodule ExCheck.Config.Generator do
 
   @generated_config """
   [
-    ## all available options with default values (see `mix check` docs for description)
-    # parallel: true,
-    # skipped: true,
+    ## don't run tools concurrently
+    # parallel: false,
+
+    ## don't print info about skipped tools
+    # skipped: false,
+
+    ## always run tools in fix mode (put it in ~/.check.exs locally, NOT in the project config)
+    # fix: true,
 
     ## list of tools (see `mix check` docs for a list of default curated tools)
     tools: [

--- a/lib/ex_check/config/generator.ex
+++ b/lib/ex_check/config/generator.ex
@@ -12,8 +12,11 @@ defmodule ExCheck.Config.Generator do
     ## don't print info about skipped tools
     # skipped: false,
 
-    ## always run tools in fix mode (put it in ~/.check.exs locally, NOT in the project config)
+    ## always run tools in fix mode (put it in ~/.check.exs locally, not in project config)
     # fix: true,
+
+    ## don't retry automatically even if last run resulted in failures
+    # failed: false,
 
     ## list of tools (see `mix check` docs for a list of default curated tools)
     tools: [

--- a/lib/ex_check/config/loader.ex
+++ b/lib/ex_check/config/loader.ex
@@ -5,7 +5,7 @@ defmodule ExCheck.Config.Loader do
   alias ExCheck.Project
 
   @config_filename ".check.exs"
-  @option_list [:parallel, :skipped]
+  @option_list [:parallel, :skipped, :fix]
 
   def load(opts) do
     config_file =

--- a/lib/ex_check/config/loader.ex
+++ b/lib/ex_check/config/loader.ex
@@ -5,7 +5,7 @@ defmodule ExCheck.Config.Loader do
   alias ExCheck.Project
 
   @config_filename ".check.exs"
-  @option_list [:parallel, :skipped, :fix]
+  @option_list [:parallel, :skipped, :fix, :failed]
 
   def load(opts) do
     config_file =

--- a/lib/ex_check/manifest.ex
+++ b/lib/ex_check/manifest.ex
@@ -1,17 +1,11 @@
 defmodule ExCheck.Manifest do
   @moduledoc false
 
-  def any_failed?(opts) do
-    opts
-    |> get_failures()
-    |> Enum.any?()
-  end
-
   def convert_failed_to_only(opts) do
     if Keyword.get(opts, :failed) do
       only =
         opts
-        |> get_failures()
+        |> get_failed_tools()
         |> Enum.map(&{:only, &1})
         |> case do
           [] -> [{:only, "-"}]
@@ -25,7 +19,7 @@ defmodule ExCheck.Manifest do
   end
 
   # sobelow_skip ["Traversal.FileModule", "DOS.StringToAtom"]
-  defp get_failures(opts) do
+  def get_failed_tools(opts) do
     manifest_path = get_path(opts)
 
     if File.exists?(manifest_path) do

--- a/lib/ex_check/manifest.ex
+++ b/lib/ex_check/manifest.ex
@@ -1,21 +1,18 @@
 defmodule ExCheck.Manifest do
   @moduledoc false
 
-  # sobelow_skip ["Traversal.FileModule", "DOS.StringToAtom"]
+  def any_failed?(opts) do
+    opts
+    |> get_failures()
+    |> Enum.any?()
+  end
+
   def convert_failed_to_only(opts) do
-    with true <- Keyword.get(opts, :failed),
-         manifest_path = get_path(opts),
-         true <- File.exists?(manifest_path) do
+    if Keyword.get(opts, :failed) do
       only =
-        manifest_path
-        |> File.read!()
-        |> String.split("\n")
-        |> Enum.map(fn
-          "FAIL " <> tool -> deserialize_tool_name_without_app(tool)
-          _ -> nil
-        end)
-        |> Enum.filter(& &1)
-        |> Enum.map(&{:only, String.to_atom(&1)})
+        opts
+        |> get_failures()
+        |> Enum.map(&{:only, &1})
         |> case do
           [] -> [{:only, "-"}]
           only -> only
@@ -23,7 +20,27 @@ defmodule ExCheck.Manifest do
 
       opts ++ only
     else
-      _ -> opts
+      opts
+    end
+  end
+
+  # sobelow_skip ["Traversal.FileModule", "DOS.StringToAtom"]
+  defp get_failures(opts) do
+    manifest_path = get_path(opts)
+
+    if File.exists?(manifest_path) do
+      manifest_path
+      |> File.read!()
+      |> String.split("\n")
+      |> Enum.map(fn
+        "FAIL " <> tool -> deserialize_tool_name_without_app(tool)
+        _ -> nil
+      end)
+      |> Enum.filter(& &1)
+      |> Enum.map(&String.to_atom/1)
+      |> Enum.uniq()
+    else
+      []
     end
   end
 

--- a/lib/mix/tasks/check.ex
+++ b/lib/mix/tasks/check.ex
@@ -144,7 +144,10 @@ defmodule Mix.Tasks.Check do
 
   You may combine `--fix` with `--failed` to only request tools that have failed to do the fixing.
 
-  Note that the fix mode will skip tools that don't provide this feature.
+  You may also consider adding `~/.check.exs` with `[fix: true]` on a local machine in order to
+  always run in the fix mode for convenience. You probably don't want this option in the project
+  config as that would trigger fix mode on CI as well - unless you want CI to perform & commit back
+  fixes.
 
   ### Manifest file
 
@@ -155,16 +158,14 @@ defmodule Mix.Tasks.Check do
 
   It's a simple plain text file with following syntax that should play well with shell commands:
 
-  ```
-  PASS compiler
-  FAIL formatter
-  PASS ex_unit
-  PASS unused_deps
-  SKIP credo
-  SKIP sobelow
-  SKIP ex_doc
-  SKIP dialyzer
-  ```
+      PASS compiler
+      FAIL formatter
+      PASS ex_unit
+      PASS unused_deps
+      SKIP credo
+      SKIP sobelow
+      SKIP ex_doc
+      SKIP dialyzer
 
   ## Configuration file
 

--- a/lib/mix/tasks/check.ex
+++ b/lib/mix/tasks/check.ex
@@ -135,6 +135,10 @@ defmodule Mix.Tasks.Check do
   `--failed` command line option is passed. This feature is provided out of the box for `ex_unit`
   tool and may be provided for any tool via `:retry` tool option in config.
 
+  Task will run in retry mode automatically even if `--failed` was not specified when a previous run
+  has resulted in any failures. You can change this behavior with `--no-failed` command line option
+  or by setting `failed: false` in config.
+
   ### Fix mode
 
   Some tools are capable of automatically resolving issues by running in the fix mode. You may take
@@ -224,13 +228,13 @@ defmodule Mix.Tasks.Check do
   ## Command line options
 
   - `--config path/to/check.exs` - override default config file
+  - `--manifest path/to/manifest` - specify path to file that holds last run results
   - `--only dialyzer --only credo ...` - run only specified check(s)
   - `--except dialyzer --except credo ...` - don't run specified check(s)
-  - `--failed` - run only checks that have failed in the last run
-  - `--fix` - run tools in fix mode in order to resolve issues automatically
-  - `--manifest path/to/manifest` - specify path to file that holds last run results
-  - `--no-parallel` - don't run tools in parallel
-  - `--no-skipped` - don't print skipped tools in summary
+  - `--[no-]failed` - (don't) run only checks that have failed in the last run
+  - `--[no-]fix` - (don't) run tools in fix mode in order to resolve issues automatically
+  - `--[no-]parallel` - (don't) run tools in parallel
+  - `--[no-]skipped` - (don't) print skipped tools in summary
 
   [`:compiler`]: https://hexdocs.pm/mix/Mix.Tasks.Compile.html
   [`:formatter`]: https://hexdocs.pm/mix/Mix.Tasks.Format.html

--- a/logo-with-name.svg
+++ b/logo-with-name.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1536 512" width="750" height="250">
+  <defs>
+    <style type="text/css">
+      @keyframes caret-flash {
+        0% { opacity: 0; }
+        25% { opacity: 1; }
+        50% { opacity: 1; }
+        85% { opacity: 0; }
+        100% { opacity: 0; }
+      }
+
+      .check {
+        transform: scale(0.35);
+        transform-box: fill-box;
+        transform-origin: 50% 50%;
+        fill: hsla(135, 80%, 80%);
+      }
+
+      .bottle {
+        fill: hsl(265, 40%, 35%);
+      }
+
+      .text {
+        font-size: 200px;
+        font-family: Courier;
+        font-weight: bold;
+        fill: hsla(135, 80%, 80%);
+      }
+
+      .text.suffix {
+        fill: hsl(265, 40%, 35%);
+      }
+
+      .text.caret {
+        animation: caret-flash 1s ease infinite;
+      }
+    </style>
+
+    <radialGradient id="bottle-shade" cx="0%" cy="0%" r="100%">
+      <stop offset="0" stop-color="hsla(265, 40%, 60%, 1)" />
+      <stop offset="1" stop-color="hsla(265, 40%, 100%, 0)" />
+    </radialGradient>
+  </defs>
+
+  <g transform="translate(80,0)">
+    <path d="M205.22 22.09c-7.94-28.78-49.44-30.12-58.44 0C100.01 179.85 0 222.72 0 333.91 0 432.35 78.72 512 176 512s176-79.65 176-178.09c0-111.75-99.79-153.34-146.78-311.82z" class="bottle"/>
+  </g>
+
+  <g transform="translate(80,0)">
+    <path d="M205.22 22.09c-7.94-28.78-49.44-30.12-58.44 0C100.01 179.85 0 222.72 0 333.91 0 432.35 78.72 512 176 512s176-79.65 176-178.09c0-111.75-99.79-153.34-146.78-311.82z" class="bottle-shade" fill="url(#bottle-shade)" />
+  </g>
+
+  <g transform="translate(0, 70)">
+    <path d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z" fill="white" class="check"/>
+  </g>
+
+  <!-- <text x="512" y="380" stroke="red" class="text">ex_check</text> -->
+  <text x="512" y="380" class="text">ex</text>
+  <text x="752" y="380" class="text caret">_</text>
+  <text x="872" y="380" class="text suffix">check</text>
+</svg>

--- a/logo-with-name.svg
+++ b/logo-with-name.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1536 512" width="600" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1536 512" width="450" height="150">
   <defs>
     <style type="text/css">
       @keyframes caret-flash {

--- a/logo-with-name.svg
+++ b/logo-with-name.svg
@@ -3,7 +3,7 @@
     <style type="text/css">
       @keyframes caret-flash {
         0% { opacity: 0; }
-        25% { opacity: 1; }
+        35% { opacity: 1; }
         50% { opacity: 1; }
         85% { opacity: 0; }
         100% { opacity: 0; }

--- a/logo-with-name.svg
+++ b/logo-with-name.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1536 512" width="750" height="250">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1536 512" width="600" height="200">
   <defs>
     <style type="text/css">
       @keyframes caret-flash {
@@ -25,6 +25,7 @@
         font-family: Courier;
         font-weight: bold;
         fill: hsla(135, 80%, 80%);
+        transform: scale(0.85, 1.0);
       }
 
       .text.suffix {
@@ -55,7 +56,7 @@
   </g>
 
   <!-- <text x="512" y="380" stroke="red" class="text">ex_check</text> -->
-  <text x="512" y="380" class="text">ex</text>
-  <text x="752" y="380" class="text caret">_</text>
-  <text x="872" y="380" class="text suffix">check</text>
+  <text x="612" y="380" class="text">ex</text>
+  <text x="852" y="380" class="text caret">_</text>
+  <text x="972" y="380" class="text suffix">check</text>
 </svg>

--- a/test/ex_check/project_cases/config_and_scripts_test.exs
+++ b/test/ex_check/project_cases/config_and_scripts_test.exs
@@ -69,7 +69,11 @@ defmodule ExCheck.ProjectCases.ConfigAndScriptsTest do
     assert plain_output =~ "compiler success"
     refute plain_output =~ "formatter success"
     assert plain_output =~ "ex_unit success"
-    assert plain_output =~ "unused_deps fix success"
+
+    if Version.match?(System.version(), ">= 1.10.0") do
+      assert plain_output =~ "unused_deps fix success"
+    end
+
     refute plain_output =~ "credo skipped due to missing package credo"
     assert plain_output =~ "my_mix_task success"
     assert plain_output =~ "my_elixir_script success"

--- a/test/ex_check/project_cases/config_and_scripts_test.exs
+++ b/test/ex_check/project_cases/config_and_scripts_test.exs
@@ -5,6 +5,7 @@ defmodule ExCheck.ProjectCases.ConfigAndScriptsTest do
   [
     parallel: false,
     skipped: false,
+    fix: true,
 
     tools: [
       {:compiler, false},
@@ -68,6 +69,7 @@ defmodule ExCheck.ProjectCases.ConfigAndScriptsTest do
     assert plain_output =~ "compiler success"
     refute plain_output =~ "formatter success"
     assert plain_output =~ "ex_unit success"
+    assert plain_output =~ "unused_deps fix success"
     refute plain_output =~ "credo skipped due to missing package credo"
     assert plain_output =~ "my_mix_task success"
     assert plain_output =~ "my_elixir_script success"

--- a/test/ex_check/project_cases/gen_config_test.exs
+++ b/test/ex_check/project_cases/gen_config_test.exs
@@ -2,6 +2,8 @@ defmodule ExCheck.ProjectCases.GenConfigTest do
   use ExCheck.ProjectCase, async: true
 
   test "gen config", %{project_dir: project_dir} do
+    File.rm!(Path.join(project_dir, ".check.exs"))
+
     assert {output, 0} = System.cmd("mix", ~w[check.gen.config], cd: project_dir)
 
     assert output =~ "creating .check.exs"
@@ -10,7 +12,7 @@ defmodule ExCheck.ProjectCases.GenConfigTest do
 
     assert output =~ ".check.exs already exists, skipped"
 
-    assert {output, 0} = System.cmd("mix", ~w[check], cd: project_dir)
+    assert {output, 0} = System.cmd("mix", ~w[check --no-fix], cd: project_dir)
 
     assert output =~ "compiler success"
     assert output =~ "formatter success"

--- a/test/ex_check/project_cases/manifest_test.exs
+++ b/test/ex_check/project_cases/manifest_test.exs
@@ -60,7 +60,7 @@ defmodule ExCheck.ProjectCases.ManifestTest do
              System.cmd("mix", ~w[check --manifest manifest.txt --failed --fix], cd: project_dir)
 
     assert output =~ "compiler success"
-    assert output =~ "formatter success"
+    assert output =~ "formatter fix success"
     refute output =~ "ex_unit success"
     refute output =~ "credo skipped due to missing package credo"
     refute output =~ "sobelow skipped due to missing package sobelow"

--- a/test/ex_check/project_cases/manifest_test.exs
+++ b/test/ex_check/project_cases/manifest_test.exs
@@ -56,10 +56,8 @@ defmodule ExCheck.ProjectCases.ManifestTest do
     refute output =~ "dialyzer skipped due to missing package dialyxir"
     refute output =~ "ex_doc skipped due to missing package ex_doc"
 
-    File.rm!(invalid_file_path)
-
     assert {output, 0} =
-             System.cmd("mix", ~w[check --manifest manifest.txt --failed], cd: project_dir)
+             System.cmd("mix", ~w[check --manifest manifest.txt --failed --fix], cd: project_dir)
 
     assert output =~ "compiler success"
     assert output =~ "formatter success"

--- a/test/ex_check/project_cases/manifest_test.exs
+++ b/test/ex_check/project_cases/manifest_test.exs
@@ -45,9 +45,9 @@ defmodule ExCheck.ProjectCases.ManifestTest do
              """
     end
 
-    assert {output, 1} =
-             System.cmd("mix", ~w[check --manifest manifest.txt --failed], cd: project_dir)
+    assert {output, 1} = System.cmd("mix", ~w[check --manifest manifest.txt], cd: project_dir)
 
+    assert output =~ "retrying automatically"
     assert output =~ "compiler success"
     assert output =~ "formatter error code 1"
     refute output =~ "ex_unit success"
@@ -55,6 +55,30 @@ defmodule ExCheck.ProjectCases.ManifestTest do
     refute output =~ "sobelow skipped due to missing package sobelow"
     refute output =~ "dialyzer skipped due to missing package dialyxir"
     refute output =~ "ex_doc skipped due to missing package ex_doc"
+
+    assert {output, 1} =
+             System.cmd("mix", ~w[check --manifest manifest.txt --failed], cd: project_dir)
+
+    refute output =~ "retrying automatically"
+    assert output =~ "compiler success"
+    assert output =~ "formatter error code 1"
+    refute output =~ "ex_unit success"
+    refute output =~ "credo skipped due to missing package credo"
+    refute output =~ "sobelow skipped due to missing package sobelow"
+    refute output =~ "dialyzer skipped due to missing package dialyxir"
+    refute output =~ "ex_doc skipped due to missing package ex_doc"
+
+    assert {output, 1} =
+             System.cmd("mix", ~w[check --manifest manifest.txt --no-failed], cd: project_dir)
+
+    refute output =~ "retrying automatically"
+    assert output =~ "compiler success"
+    assert output =~ "formatter error code 1"
+    assert output =~ "ex_unit success"
+    assert output =~ "credo skipped due to missing package credo"
+    assert output =~ "sobelow skipped due to missing package sobelow"
+    assert output =~ "dialyzer skipped due to missing package dialyxir"
+    assert output =~ "ex_doc skipped due to missing package ex_doc"
 
     assert {output, 0} =
              System.cmd("mix", ~w[check --manifest manifest.txt --failed --fix], cd: project_dir)

--- a/test/ex_check/project_cases/manifest_test.exs
+++ b/test/ex_check/project_cases/manifest_test.exs
@@ -100,17 +100,18 @@ defmodule ExCheck.ProjectCases.ManifestTest do
     assert output =~ "ex_unit error code 1"
     assert output =~ "2 tests, 1 failure"
 
-    assert {output, 1} =
-             System.cmd("mix", ~w[check --failed], cd: project_dir)
+    assert {output, 1} = System.cmd("mix", ~w[check --failed], cd: project_dir)
 
     refute output =~ "formatter"
     assert output =~ "ex_unit error code 1"
     assert output =~ "1 test, 1 failure"
 
-    File.write!(failing_test_path, File.read!(failing_test_path) |> String.replace(":universe", ":world"))
+    File.write!(
+      failing_test_path,
+      File.read!(failing_test_path) |> String.replace(":universe", ":world")
+    )
 
-    assert {output, 0} =
-             System.cmd("mix", ~w[check --failed], cd: project_dir)
+    assert {output, 0} = System.cmd("mix", ~w[check --failed], cd: project_dir)
 
     refute output =~ "formatter"
     assert output =~ "ex_unit retry success"

--- a/test/support/ex_check/project_case.ex
+++ b/test/support/ex_check/project_case.ex
@@ -3,6 +3,12 @@ defmodule ExCheck.ProjectCase do
 
   use ExUnit.CaseTemplate
 
+  @default_config """
+  [
+    fix: false
+  ]
+  """
+
   using do
     quote do
       import ExCheck.ProjectCase
@@ -14,6 +20,7 @@ defmodule ExCheck.ProjectCase do
         project_dir = create_mix_project(tmp_dir)
 
         set_mix_deps(project_dir, [:ex_check])
+        write_default_config(project_dir)
         on_exit(fn -> remove_tmp_directory(tmp_dir) end)
 
         {:ok, project_dir: project_dir}
@@ -99,5 +106,10 @@ defmodule ExCheck.ProjectCase do
 
     File.write!(config_path, new_config)
     {_, 0} = System.cmd("mix", ~w[format], cd: project_dir)
+  end
+
+  def write_default_config(project_dir) do
+    config_path = Path.join(project_dir, ".check.exs")
+    File.write!(config_path, @default_config)
   end
 end

--- a/test/support/ex_check/umbrella_project_case.ex
+++ b/test/support/ex_check/umbrella_project_case.ex
@@ -3,6 +3,12 @@ defmodule ExCheck.UmbrellaProjectCase do
 
   use ExUnit.CaseTemplate
 
+  @default_config """
+  [
+    fix: false
+  ]
+  """
+
   using do
     quote do
       import ExCheck.UmbrellaProjectCase
@@ -18,6 +24,7 @@ defmodule ExCheck.UmbrellaProjectCase do
         project_dirs = [project_dir, child_a_dir, child_b_dir]
 
         set_mix_deps(project_dirs, [:ex_check])
+        write_default_config(project_dir)
         on_exit(fn -> remove_tmp_directory(tmp_dir) end)
 
         {:ok, project_dirs: project_dirs}
@@ -111,5 +118,10 @@ defmodule ExCheck.UmbrellaProjectCase do
 
     File.write!(config_path, new_config)
     {_, 0} = System.cmd("mix", ~w[format], cd: project_dir)
+  end
+
+  def write_default_config(project_dir) do
+    config_path = Path.join(project_dir, ".check.exs")
+    File.write!(config_path, @default_config)
   end
 end


### PR DESCRIPTION
- **Added** `--fix` command line option that runs tools in fix mode in order to resolve issues automatically along with `:fix` tool option
- **Added** capability to run tool command to retry after failure e.g. in order to run only failed tests or checks along with `:retry` tool option
