### PR TITLE
Add top-level :retry config documentation

### DIFF
--- a/lib/mix/tasks/check.ex
+++ b/lib/mix/tasks/check.ex
@@ -184,8 +184,9 @@ defmodule Mix.Tasks.Check do
 
   - `:parallel` - toggles running tools in parallel; default: `true`
   - `:skipped` - toggles printing skipped tools in summary; default: `true`
+  - `:fix` - toggles running tools in fix mode in order to resolve issues automatically; default: `false`
+  - `:retry` - toggles running only checks that have failed in the last run; default: 'true' if manifest exists
   - `:tools` - a list of tools to run; default: curated tools; more info below
-  - `:skip` - toggles automatically running task in retry mode if running after a failure; default: `true`
 
   Tool list under `:tools` key may contain following tool tuples:
 

--- a/lib/mix/tasks/check.ex
+++ b/lib/mix/tasks/check.ex
@@ -185,6 +185,7 @@ defmodule Mix.Tasks.Check do
   - `:parallel` - toggles running tools in parallel; default: `true`
   - `:skipped` - toggles printing skipped tools in summary; default: `true`
   - `:tools` - a list of tools to run; default: curated tools; more info below
+  - `:skip` - toggles automatically running task in retry mode if running after a failure; default: `true`
 
   Tool list under `:tools` key may contain following tool tuples:
 


### PR DESCRIPTION
The part that was listing the top-level config options for `.check.exs` was not mentioning the `:retry` option (it was only mentioned when talking about `--retry` instead).

This PR adds this to that list so people feel more confident on how to configure this behavior.

Thank you!