### PR TITLE
 Fix file detection paths in Elixir 1.16

### DIFF
--- a/lib/ex_check/check/compiler.ex
+++ b/lib/ex_check/check/compiler.ex
@@ -180,9 +180,9 @@ defmodule ExCheck.Check.Compiler do
   defp prepare_detection_base({:file, name}, _, tool_opts) do
     filename =
       tool_opts
-      |> Keyword.get(:cd, ".")
+      |> Keyword.get(:cd, "")
       |> Path.join(name)
-      |> Path.relative_to(".")
+      |> Path.relative_to_cwd()
 
     {:file, filename}
   end


### PR DESCRIPTION
In Elixir 1.16 the file detection paths have an additional `../` in front, causing the detection to fail.

This PR fixes this by changing from `Path.relative_to(".")` to `Path.relative_to_cwd()`.

`find_failed_detection` before

```
[(ex_check 0.15.0) lib/ex_check/check/compiler.ex:162: ExCheck.Check.Compiler.find_failed_detection/2]
...
|> Keyword.get(:detect, []) #=> [file: "test"]
|> Enum.map(&split_detection_opts/1) #=> [{{:file, "test"}, []}]
|> Enum.map(fn {base, opts} -> {prepare_detection_base(base, name, tool_opts), opts} end) #=> [{{:file, "../test"}, []}]
|> Enum.find(fn {base, _} -> failed_detection?(base) end) #=> {{:file, "../test"}, []}

...

[(ex_check 0.15.0) lib/ex_check/check/compiler.ex:162: ExCheck.Check.Compiler.find_failed_detection/2]
...
|> Keyword.get(:detect, []) #=> [file: ".formatter.exs"]
|> Enum.map(&split_detection_opts/1) #=> [{{:file, ".formatter.exs"}, []}]
|> Enum.map(fn {base, opts} -> {prepare_detection_base(base, name, tool_opts), opts} end) #=> [{{:file, "../.formatter.exs"}, []}]
|> Enum.find(fn {base, _} -> failed_detection?(base) end) #=> {{:file, "../.formatter.exs"}, []}
```

`find_failed_detection` after

```
[(ex_check 0.15.0) lib/ex_check/check/compiler.ex:162: ExCheck.Check.Compiler.find_failed_detection/2]
...
|> Keyword.get(:detect, []) #=> [file: "test"]
|> Enum.map(&split_detection_opts/1) #=> [{{:file, "test"}, []}]
|> Enum.map(fn {base, opts} -> {prepare_detection_base(base, name, tool_opts), opts} end) #=> [{{:file, "test"}, []}]
|> Enum.find(fn {base, _} -> failed_detection?(base) end) #=> nil

...

[(ex_check 0.15.0) lib/ex_check/check/compiler.ex:162: ExCheck.Check.Compiler.find_failed_detection/2]
...
|> Keyword.get(:detect, []) #=> [file: ".formatter.exs"]
|> Enum.map(&split_detection_opts/1) #=> [{{:file, ".formatter.exs"}, []}]
|> Enum.map(fn {base, opts} -> {prepare_detection_base(base, name, tool_opts), opts} end) #=> [{{:file, ".formatter.exs"}, []}]
|> Enum.find(fn {base, _} -> failed_detection?(base) end) #=> nil
```

Fixes #41

